### PR TITLE
resolve failing doc server builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ docs = [
     "enum-tools[sphinx]>=0.12.0",
     "furo>=2024.8.6",
     "myst-parser>=4.0.0",
-    "sphinx>=8.1.3",
+    "sphinx==8.1.3",
     "sphinx-autodoc-typehints>=3.0.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1022,7 +1022,7 @@ requires-dist = [
     { name = "grpcio", specifier = ">=1.69.0" },
     { name = "grpcio-tools", specifier = ">=1.69.0" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=4.0.0" },
-    { name = "sphinx", marker = "extra == 'docs'", specifier = ">=8.1.3" },
+    { name = "sphinx", marker = "extra == 'docs'", specifier = "==8.1.3" },
     { name = "sphinx-autodoc-typehints", marker = "extra == 'docs'", specifier = ">=3.0.0" },
     { name = "types-protobuf", specifier = ">=5.29.1.20241207" },
 ]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Pin Sphinx version to 8.1.3 in `pyproject.toml` and `uv.lock` to fix build failures.
> 
>   - **Dependencies**:
>     - Pin `sphinx` version to `8.1.3` in `pyproject.toml` and `uv.lock` to fix build failures.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=s2-streamstore%2Fs2-sdk-python&utm_source=github&utm_medium=referral)<sup> for c8c4398b8e265bff066cafa08fb0c618b132e068. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->