### PR TITLE
chore: migrate submodule from protos to s2-specs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "protos"]
-	path = protos
-	url = https://github.com/s2-streamstore/s2-protos.git
+[submodule "s2-specs"]
+	path = s2-specs
+	url = https://github.com/s2-streamstore/s2-specs.git

--- a/update_protos
+++ b/update_protos
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 cd src/streamstore/_lib
-uv run python -m grpc_tools.protoc -I../../../protos --python_out=. --pyi_out=. --grpc_python_out=. ../../../protos/s2/v1alpha/s2.proto
+uv run python -m grpc_tools.protoc -I../../../s2-specs --python_out=. --pyi_out=. --grpc_python_out=. ../../../s2-specs/s2/v1alpha/s2.proto
 # workaround for https://github.com/protocolbuffers/protobuf/issues/7061
 find . -name '*.py' | xargs -I{} sed -i '' 's/from s2\.\(v[0-9][a-z0-9]*\) import s2_pb2 as s2_dot_\1_dot_s2__pb2/from streamstore._lib.s2.\1 import s2_pb2 as s2_dot_\1_dot_s2__pb2/' {}
 uv run poe checker


### PR DESCRIPTION
## Summary
- Rename submodule from `protos` to `s2-specs`
- Update submodule URL to `s2-specs` repository
- Update `update_protos` script to use new submodule path

## Test plan
- [ ] Verify submodule points to s2-specs
- [ ] Verify `./update_protos` script works with new path

🤖 Generated with [Claude Code](https://claude.ai/claude-code)